### PR TITLE
fix remove_owners missing quotes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = 'datahub_tools'
 description = 'Python tools for working with DataHub'
-version = '1.0.2'
+version = '1.0.3'
 readme = 'README.md'
 requires-python = '>=3.7'
 dependencies = [

--- a/src/datahub_tools/client.py
+++ b/src/datahub_tools/client.py
@@ -461,7 +461,7 @@ def _set_owner(owner: str, urns: List[str]):
 def remove_owners(owners: Iterable[str], urns: List[str]):
     if isinstance(owners, str):
         owners = [owners]
-    owner_urns = ", ".join(owners)
+    owner_urns = ", ".join(f'"{owner}"' for owner in owners)
     resource_urns = ", ".join([f'{{ resourceUrn: "{urn}" }}' for urn in urns])
     _input = f"{{ ownerUrns: [ {owner_urns} ], resources: [ {resource_urns} ] }}"
     response = _post_mutation(endpoint="batchRemoveOwners", _input=_input)


### PR DESCRIPTION
fixes `ownerUrns` missing required quotes in the post body of the `remove_owners` functions causing `Invalid Syntax` error from graphql endpoint 