### PR TITLE
update_field_descriptions and get_datahub_entities changes

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,45 +1,71 @@
 # Change Log
 
+### v2.1.0 - 2023-07-17 Theodore Wou
+
+#### Changes
+
+- `update_field_descriptions` now uses the `updateDescription` endpoint to prevent overwriting
+  of tags & glossary terms
+- `get_datahub_entities` now accepts an optional `resource_urns` argument to retrieve only the specified urns
+
 ### v2.0.1 - 2023-07-20 Ada Draginda
-* Fix in `get_datahub_entities`: updated how we fetch the owner type as the underlying API had changed.
+
+- Fix in `get_datahub_entities`: updated how we fetch the owner type as the underlying API had changed.
 
 ### v2.0.0 - 2023-07-12 Ada Draginda
+
 #### Deprecations
-* groups and users selection and return have been changed significantly to meet
-the new format by acryl.
+
+- groups and users selection and return have been changed significantly to meet
+  the new format by acryl.
+
 #### Changes
-* minimum version of acryl-datahub is now 0.10.3.2
+
+- minimum version of acryl-datahub is now 0.10.3.2
 
 ### v1.1.0 - 2023-05-23 Ada Draginda
+
 #### Changes
-* Added a get_glossary_terms function
+
+- Added a get_glossary_terms function
+
 #### Fixes
-* Fix an incorrect substitution when fetching entities
+
+- Fix an incorrect substitution when fetching entities
 
 ### v1.0.0 - 2023-02-21 Ada Draginda
+
 #### Deprecations
-* `extract_dbt_resources` has moved from a soft to a hard deprecation. Instead, use
-`datahub_tools.dbt.extract_dbt_resources`
-* `client.update_descriptions` has moved from a soft to a hard deprecation. Instead, use
-`update_field_descriptions` or `update_dataset_description`
+
+- `extract_dbt_resources` has moved from a soft to a hard deprecation. Instead, use
+  `datahub_tools.dbt.extract_dbt_resources`
+- `client.update_descriptions` has moved from a soft to a hard deprecation. Instead, use
+  `update_field_descriptions` or `update_dataset_description`
 
 #### Changes
-* DataHub posts are now logged with fewer linebreaks and repeated spaces
-* `client.get_datahub_entities` no longer returns schema data, by default. You can turn this feature
-back on with the `with_schema` argument. This change was made for performance reasons.
+
+- DataHub posts are now logged with fewer linebreaks and repeated spaces
+- `client.get_datahub_entities` no longer returns schema data, by default. You can turn this feature
+  back on with the `with_schema` argument. This change was made for performance reasons.
 
 ### v0.4.0 - 2023-02-09 Ada Draginda
+
 #### Changes
-* Added new `get_owners` to the client module
+
+- Added new `get_owners` to the client module
 
 ### v0.3.0 - 2023-02-07 Ada Draginda
+
 #### Changes
-* Added a example on how to use transformers
-* New DBT module for fetching DBT dependency lineage
+
+- Added a example on how to use transformers
+- New DBT module for fetching DBT dependency lineage
 
 ### v0.2.0 - 2023-01-31 Ada Draginda
+
 #### Deprecations
-* `client.update_description` has been deprecated in favor of `client.update_field_descriptions`
-or `client.update_dataset_description` as the original function does not work with datasets (only fields).
-The new functions have also been changed to operate on editable descriptions instead of descriptions. The
-deprecated function will be removed in `v1.0.0`
+
+- `client.update_description` has been deprecated in favor of `client.update_field_descriptions`
+  or `client.update_dataset_description` as the original function does not work with datasets (only fields).
+  The new functions have also been changed to operate on editable descriptions instead of descriptions. The
+  deprecated function will be removed in `v1.0.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,14 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = 'datahub_tools'
 description = 'Python tools for working with DataHub'
-version = '2.0.1'
+version = '2.1.0'
 readme = 'README.md'
 requires-python = '>=3.7'
-dependencies = [
-    'acryl-datahub>=0.10.3.2',
-    'jmespath',
-    'requests'
-]
+dependencies = ['acryl-datahub>=0.10.3.2', 'jmespath', 'requests']
 
 [tool.setuptools]
 include-package-data = false
-package-dir = {"" = "src"}
+package-dir = { "" = "src" }
 
 [tool.black]
 target-version = ['py37']
@@ -59,7 +55,7 @@ commands = pytest
 select = ["B", "C", "E", "F", "I", "N", "W", "RUF"]
 
 fixable = [
-    "I",    # isort
+    "I", # isort
 ]
 unfixable = []
 


### PR DESCRIPTION
Issue: When using the `update_field_descriptions` function the glossary terms (and possibly tags) entries for that field are being erased.

The [EditableSchemaFieldInfoUpdate argument](https://datahubproject.io/docs/graphql/inputObjects#editableschemafieldinfoupdate) doesn't seem to accept glossary terms, only tags, so we can instead use the updateDescription mutation (currently in incubation but seems to be working fine)

Also added the ability to query URNs directly from `get_datahub_entities` - thought this was necessary to supply existing tags/glossary terms before I realized EditableSchemaFieldInfoUpdate doesn't accept glossary terms.... but still a useful feature nonetheless 