### PR TITLE
create DHEntity from standard dictionary

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
+### v2.2.0 - 2023-09-20 Theo Wou
+
+#### Changes
+
+- Extend DHEntity.from_dict() to add the ability to create a DHEntity from a standard dictionary
+
 ### v2.1.1 - 2023-09-20 Theo Wou
+
+#### Fixes
 
 - Fix extraneous braces in `get_datahub_entities`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = 'datahub_tools'
 description = 'Python tools for working with DataHub'
-version = '2.1.1'
+version = '2.2.0'
 readme = 'README.md'
 requires-python = '>=3.7'
 dependencies = ['acryl-datahub>=0.10.3.2', 'jmespath', 'requests']

--- a/src/datahub_tools/classes.py
+++ b/src/datahub_tools/classes.py
@@ -129,7 +129,7 @@ class DHEntity(DH):
         )
         editable_description = jmespath.search(
             "editableProperties.description", _dict
-        ) or _dict.get("editable_description")
+        ) or _dict.get("_editable_description")
 
         raw_tags = jmespath.search("tags.tags", _dict) or _dict.get("_tags") or []
         tags = [


### PR DESCRIPTION
Add ability to create a DHEntity from a standard dictionary (as opposed to to the graphQL returned object that requires jmespath)

Keys are prefixed with `_` to prevent collisions with graphQL returned keys that have incompatible types

```
DHEntity.from_dict(
    {
        "_name": "foo_entity",
        "_description": "foo description",
        "_fields": [
            {
                "fieldPath": "foo_column",
                "description": "foo desc",
                "tags": None,
                "glossaryTerms": None
            },
            {
                "fieldPath": "bar_column",
                "description": "bar desc",
                "tags": None,
                "glossaryTerms": None
            },
        ],
        "_urn": "foo_bar_urn"
    }
)


DHEntity(name='foo_entity', urn='foo_bar_urn', description='foo description', editable_description=None, fields=[DHEntityField(name='foo_column', type=None, description='foo desc', tags=None, glossary_terms=None), DHEntityField(name='bar_column', type=None, description='bar desc', tags=None, glossary_terms=None)], editable_fields=[], metadata={}, owners=defaultdict(<class 'list'>, {}), tags=[])
```