### PR TITLE
Add filters kwarg to get_datahub_entities

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+### v2.3.0 - 2026-05-19 Evelyn Wou
+
+- `get_datahub_entities` now accepts an optional `filters` argument (a list of
+  GraphQL `FacetFilterInput` dicts) so callers can narrow the underlying search.
+  This is the recommended way to avoid OpenSearch's `index.max_result_window`
+  cap (typically 10,000) when more than ~10k datasets exist. Cannot be combined
+  with `resource_urns`.
+- The `DataFetchingException` short-circuit in `get_datahub_entities` now logs a
+  warning before breaking out of the loop. Previously this branch silently
+  truncated results when the result-window cap was hit.
+
 ### v2.2.1 - 2025-03-12 Peter Ray
 
 - Add group info to get users function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = 'datahub_tools'
 description = 'Python tools for working with DataHub'
-version = '2.2.1'
+version = '2.3.0'
 readme = 'README.md'
 requires-python = '>=3.9'
 dependencies = ['acryl-datahub>=0.10.3.2', 'jmespath', 'requests']

--- a/src/datahub_tools/client.py
+++ b/src/datahub_tools/client.py
@@ -135,8 +135,8 @@ def _format_facet_filters(filters: list[dict[str, str]]) -> str:
     rendered = []
     for f in filters:
         parts = ", ".join(f"{k}: {json.dumps(v)}" for k, v in f.items())
-        rendered.append("{" + parts + "}")
-    return "[" + ", ".join(rendered) + "]"
+        rendered.append(f"{{{parts}}}")
+    return f"[{', '.join(rendered)}]"
 
 
 def get_datahub_entities(  # noqa: C901

--- a/src/datahub_tools/client.py
+++ b/src/datahub_tools/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import os
 import re
@@ -120,12 +121,31 @@ def emit_metadata(
     emitter.emit(metadata_event)
 
 
-def get_datahub_entities(
+def _format_facet_filters(filters: list[dict[str, str]]) -> str:
+    """
+    Render a list of FacetFilterInput dicts as a GraphQL inline argument value.
+
+    ``[{"field": "platform", "value": "urn:li:dataPlatform:dbt"}]``
+    becomes
+    ``[{field: "platform", value: "urn:li:dataPlatform:dbt"}]``
+
+    Field names are emitted unquoted (GraphQL identifiers); values are emitted
+    as JSON-escaped string literals.
+    """
+    rendered = []
+    for f in filters:
+        parts = ", ".join(f"{k}: {json.dumps(v)}" for k, v in f.items())
+        rendered.append("{" + parts + "}")
+    return "[" + ", ".join(rendered) + "]"
+
+
+def get_datahub_entities(  # noqa: C901
     start: int = 0,
     limit: int | None = None,
     with_schema: bool = False,
     chunk_size: int | None = None,
     resource_urns: list[str] | None = None,
+    filters: list[dict[str, str]] | None = None,
 ) -> list[DHEntity]:
     """
     :param start: Index of the first record to return
@@ -136,9 +156,20 @@ def get_datahub_entities(
     :param chunk_size: If provided, the entities will be retrieved in chunks of this
       size.
     :param resource_urns: Optional list of dataset resource_urns
+    :param filters: Optional list of DataHub ``FacetFilterInput`` dicts applied to
+      the underlying search call, e.g.
+      ``[{"field": "platform", "value": "urn:li:dataPlatform:dbt"}]``. Each dict
+      is passed through to GraphQL as-is. Useful for narrowing very large result
+      sets that would otherwise hit OpenSearch's ``index.max_result_window`` cap
+      (typically 10,000) on unfiltered searches. Cannot be combined with
+      ``resource_urns``.
     :return: dictionary of snowflake name (e.g. prep.core.calendar) to DataHub urn
       e.g. urn:li:dataset:(urn:li:dataPlatform:snowflake,prep.core.calendar,PROD)
     """
+    if filters and resource_urns:
+        raise ValueError("`filters` cannot be combined with `resource_urns`")
+
+    filters_clause = f", filters: {_format_facet_filters(filters)}" if filters else ""
     # reuse the same set of vars for fields (editable and non-editable fields)
     field_vars = dedent(
         """
@@ -257,7 +288,7 @@ def get_datahub_entities(
             query_body = Template(
                 """
                 {
-                    search(input: {type: DATASET, query: "*", start: $start, count: $limit}){
+                    search(input: {type: DATASET, query: "*", start: $start, count: $limit$filters_clause}){
                         start
                         count
                         searchResults {
@@ -266,7 +297,12 @@ def get_datahub_entities(
                     }
                 }
                 """
-            ).substitute(start=_start, limit=_chunk_size, query_fields=query_fields)
+            ).substitute(
+                start=_start,
+                limit=_chunk_size,
+                query_fields=query_fields,
+                filters_clause=filters_clause,
+            )
 
         body = {"query": query_body, "variables": {}}
 
@@ -282,6 +318,15 @@ def get_datahub_entities(
                     "errors[0].extensions.classification", e.args[0]
                 )
                 if error_classification == "DataFetchingException":
+                    logging.getLogger(__name__).warning(
+                        "Stopping iteration at start=%s: DataHub returned DataFetchingException. "
+                        "This commonly indicates OpenSearch's index.max_result_window has been "
+                        "exceeded; consider narrowing the search via `filters`. Returning the "
+                        "%s entities collected so far. Error: %s",
+                        _start,
+                        len(out),
+                        e.args[0],
+                    )
                     break
                 else:
                     raise e


### PR DESCRIPTION
## Summary

- `get_datahub_entities` now accepts a `filters` kwarg (a list of GraphQL `FacetFilterInput` dicts) that's passed through to the underlying `search` call. Cannot be combined with `resource_urns`.
- The `DataFetchingException` short-circuit in the pagination loop now logs a warning before breaking. Previously it silently truncated results.
- Version bumped 2.2.1 → 2.3.0; CHANGE_LOG updated.

## Why

The unfiltered `search(type: DATASET, query: "*")` call is bounded by OpenSearch's `index.max_result_window` (typically 10,000). In a DataHub instance with more than ~10k datasets, deep pagination errors with `Result window is too large, from + size must be less than or equal to: [10000]`. The existing `DataFetchingException` catch swallowed that error and exited the loop, returning a silently-truncated list.

Concretely, in one of our setups all 10,000 returned entities were on a single platform (Athena), and every dbt and Snowflake dataset was past the cap and invisible to callers — which caused downstream lookups against `dbt_unique_id` to silently miss every model.

Filtering by platform (`filters=[{"field": "platform", "value": "urn:li:dataPlatform:dbt"}]`) is the documented OpenSearch workaround and keeps each page well under the cap.

## Backward compatibility

Default behavior is unchanged when `filters` is not passed; existing callers see no difference. The new warning log fires only on the error path that was previously silent.

## Test plan

- [x] Logic-only tests for `_format_facet_filters` (empty/single/multiple/quote/backslash/newline escaping)
- [x] `filters` + `resource_urns` raises `ValueError`
- [x] Live call against real DataHub
- [x] `uvx ruff check` clean
- [x] `uvx --from black==24.10.0 black --check` clean
