### PR TITLE
Remove Contact/Author section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,3 @@ pre-commit install
 ```
 
 The pre-commit hooks will run automatically upon a commit
-
-### Contact/Author
-
-Contact [Evelyn Wou](https://www.linkedin.com/in/evelyn-wou-b7053b238/) <evelyn[at]makenotion.com>
-Originally authored by [Ada Draginda](https://www.linkedin.com/in/adadraginda/)


### PR DESCRIPTION
## Summary

Drops the `### Contact/Author` block at the bottom of the README